### PR TITLE
fix: remove nextafter, signbit, use `acb(1j)` in `hypot`, fix `linspace()` and `result_type()` type checking

### DIFF
--- a/src/numpy_flint_arb/_main.py
+++ b/src/numpy_flint_arb/_main.py
@@ -439,7 +439,8 @@ namespace["reciprocal"] = np.reciprocal
 namespace["remainder"] = np.remainder
 # namespace["round"] = None
 namespace["sign"] = np.vectorize(lambda x: x.sgn())
-namespace["signbit"] = np.vectorize(lambda x: x.sgn())
+# no signbit
+# namespace["signbit"] = np.vectorize(lambda x: x.sgn())
 namespace["sin"] = np.vectorize(lambda x: x.sin())
 namespace["sinh"] = np.vectorize(lambda x: x.sinh())
 namespace["square"] = np.vectorize(lambda x: x**2)

--- a/src/numpy_flint_arb/_main.py
+++ b/src/numpy_flint_arb/_main.py
@@ -410,7 +410,7 @@ namespace["floor"] = np.vectorize(lambda x: x.floor())
 namespace["floor_divide"] = np.floor_divide
 namespace["greater"] = np.greater
 namespace["greater_equal"] = np.greater_equal
-namespace["hypot"] = np.vectorize(lambda x1, x2: abs(x1 + x2 * 1j))
+namespace["hypot"] = np.vectorize(lambda x1, x2: abs(x1 + x2 * acb(1j)))
 namespace["imag"] = np.vectorize(lambda x: x.imag if hasattr(x, "imag") else acb.imag(x))
 namespace["isfinite"] = np.vectorize(
     lambda x: x.is_finite() if hasattr(x, "is_finite") else np.isfinite(x)

--- a/src/numpy_flint_arb/_main.py
+++ b/src/numpy_flint_arb/_main.py
@@ -6,7 +6,7 @@ import numpy as np
 from array_api.latest import Array, ArrayNamespaceFull
 from flint import acb, acb_mat, arb, arb_mat, arf, ctx, fmpq, fmpq_mat, fmpz, fmpz_mat
 
-dtypes = [acb, arb, arf, fmpz, fmpq]
+dtypes = (acb, arb, arf, fmpz, fmpq)
 
 _ALLOW_FLOAT_INPUT = False
 _ALLOW_NONINTERVAL_INPUT = False
@@ -260,13 +260,20 @@ for name in [
 def linspace(
     start: Any, stop: Any, /, num: int = 50, dtype: Any = None, device: Any = None
 ) -> np.ndarray:
-    if start not in dtypes:
+    if not isinstance(start, dtypes):
         raise TypeError("start must be a flint type.")
-    if stop not in dtypes:
+    if not isinstance(stop, dtypes):
         raise TypeError("stop must be a flint type.")
+    if num < 0:
+        raise ValueError("num must be a non-negative integer.")
     dtype = result_type(start, stop, dtype)
-    diff = (stop - start) / (num - 1) if num > 1 else 0
-    diff = dtype(diff)
+    start = dtype(start)
+    stop = dtype(stop)
+    if num <= 1:
+        diff = dtype(0)
+    else:
+        diff = (stop - start) / (num - 1)
+        diff = dtype(diff)
     return start + diff * namespace["arange"](num, dtype=dtype)
 
 
@@ -366,7 +373,11 @@ namespace["iinfo"] = iinfo
 def result_type(*arrays_and_dtypes: Any) -> Any:
     types = []
     for x in arrays_and_dtypes:
-        if x in dtypes or np.issubdtype(x, np.number):
+        if x in dtypes:
+            types.append(x)
+        elif isinstance(x, dtypes):
+            types.append(type(x))
+        elif np.issubdtype(x, np.number):
             types.append(x)
         else:
             types.append(_fltype(x))

--- a/src/numpy_flint_arb/_main.py
+++ b/src/numpy_flint_arb/_main.py
@@ -430,7 +430,7 @@ namespace["minimum"] = np.vectorize(lambda x1, x2: x1.min(x2))
 namespace["multiply"] = np.multiply
 namespace["negative"] = np.negative
 # no nextafter
-namespace["nextafter"] = np.vectorize(lambda x1, x2: x1)
+# namespace["nextafter"] = np.vectorize(lambda x1, x2: x1)
 namespace["not_equal"] = np.not_equal
 namespace["positive"] = np.positive
 namespace["pow"] = np.pow


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/34j/numpy-flint-arb/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/34j/numpy-flint-arb/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
